### PR TITLE
PRODUCT-4129,PRODUCT-4130

### DIFF
--- a/airbyte-integrations/connectors/source-commercetools/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-commercetools/integration_tests/configured_catalog.json
@@ -1,64 +1,200 @@
 {
   "streams": [
     {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
       "stream": {
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
+        "json_schema": {},
         "name": "customers",
-        "json_schema": {},
-        "supported_sync_modes": ["incremental", "full_refresh"],
+        "namespace": null,
         "source_defined_cursor": true,
-        "default_cursor_field": ["lastModifiedAt"]
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
       },
-      "sync_mode": "incremental",
-      "cursor_field": ["lastModifiedAt"],
-      "destination_sync_mode": "append"
+      "sync_id": null,
+      "sync_mode": "full_refresh"
     },
     {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
       "stream": {
-        "name": "orders",
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
         "json_schema": {},
-        "supported_sync_modes": ["incremental", "full_refresh"],
-        "source_defined_cursor": true,
-        "default_cursor_field": ["lastModifiedAt"]
-      },
-      "sync_mode": "incremental",
-      "cursor_field": ["lastModifiedAt"],
-      "destination_sync_mode": "append"
-    },
-    {
-      "stream": {
         "name": "discount_codes",
-        "json_schema": {},
-        "supported_sync_modes": ["incremental", "full_refresh"],
+        "namespace": null,
         "source_defined_cursor": true,
-        "default_cursor_field": ["lastModifiedAt"]
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
       },
-      "sync_mode": "incremental",
-      "cursor_field": ["lastModifiedAt"],
-      "destination_sync_mode": "append"
+      "sync_id": null,
+      "sync_mode": "full_refresh"
     },
     {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
       "stream": {
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
+        "json_schema": {},
+        "name": "orders",
+        "namespace": null,
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
+      },
+      "sync_id": null,
+      "sync_mode": "full_refresh"
+    },
+    {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
+      "stream": {
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
+        "json_schema": {},
         "name": "payments",
-        "json_schema": {},
-        "supported_sync_modes": ["incremental", "full_refresh"],
+        "namespace": null,
         "source_defined_cursor": true,
-        "default_cursor_field": ["lastModifiedAt"]
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
       },
-      "sync_mode": "incremental",
-      "cursor_field": ["lastModifiedAt"],
-      "destination_sync_mode": "append"
+      "sync_id": null,
+      "sync_mode": "full_refresh"
     },
     {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
       "stream": {
-        "name": "products",
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
         "json_schema": {},
-        "supported_sync_modes": ["incremental", "full_refresh"],
+        "name": "products",
+        "namespace": null,
         "source_defined_cursor": true,
-        "default_cursor_field": ["lastModifiedAt"]
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
       },
-      "sync_mode": "incremental",
-      "cursor_field": ["lastModifiedAt"],
-      "destination_sync_mode": "append"
+      "sync_id": null,
+      "sync_mode": "full_refresh"
+    },
+    {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
+      "stream": {
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
+        "json_schema": {},
+        "name": "carts",
+        "namespace": null,
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
+      },
+      "sync_id": null,
+      "sync_mode": "full_refresh"
+    },
+    {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "generation_id": null,
+      "minimum_generation_id": null,
+      "primary_key": null,
+      "stream": {
+        "default_cursor_field": [
+          "lastModifiedAt"
+        ],
+        "is_resumable": true,
+        "json_schema": {},
+        "name": "inventory",
+        "namespace": null,
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ]
+      },
+      "sync_id": null,
+      "sync_mode": "full_refresh"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-commercetools/source_commercetools/manifest.yaml
+++ b/airbyte-integrations/connectors/source-commercetools/source_commercetools/manifest.yaml
@@ -114,12 +114,26 @@ definitions:
       name: "products"
       path: "products"
 
+  carts_stream:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      name: "carts"
+      path: "carts"
+
+  inventory_stream:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      name: "inventory"
+      path: "inventory"
+
 streams:
   - "#/definitions/customers_stream"
   - "#/definitions/discount_codes_stream"
   - "#/definitions/orders_stream"
   - "#/definitions/payments_stream"
   - "#/definitions/products_stream"
+  - "#/definitions/carts_stream"
+  - "#/definitions/inventory_stream"
 
 spec:
   documentation_url: https://docs.airbyte.com/integrations/sources/commercetools

--- a/airbyte-integrations/connectors/source-commercetools/source_commercetools/schemas/carts.json
+++ b/airbyte-integrations/connectors/source-commercetools/source_commercetools/schemas/carts.json
@@ -1,0 +1,1589 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "billingAddress": {
+      "additionalProperties": true,
+      "properties": {
+        "additionalAddressInfo": {
+          "type": "string"
+        },
+        "additionalStreetInfo": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "streetName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "cartState": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "createdBy": {
+      "additionalProperties": true,
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "isPlatformClient": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "custom": {
+      "additionalProperties": true,
+      "properties": {
+        "fields": {
+          "additionalProperties": true,
+          "properties": {
+            "isAgeOfMajority": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "additionalProperties": true,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "typeId": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "customLineItems": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "discountedPricePerQuantity": {
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "money": {
+            "additionalProperties": true,
+            "properties": {
+              "centAmount": {
+                "type": "integer"
+              },
+              "currencyCode": {
+                "type": "string"
+              },
+              "fractionDigits": {
+                "type": "integer"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "additionalProperties": true,
+            "properties": {
+              "en": {
+                "type": "string"
+              },
+              "es": {
+                "type": "string"
+              },
+              "fr": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "perMethodTaxRate": {
+            "type": "array"
+          },
+          "priceMode": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "state": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "quantity": {
+                  "type": "integer"
+                },
+                "state": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "typeId": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "taxCategory": {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "typeId": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "taxRate": {
+            "additionalProperties": true,
+            "properties": {
+              "amount": {
+                "type": "number"
+              },
+              "country": {
+                "type": "string"
+              },
+              "includedInPrice": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              },
+              "subRates": {
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "taxedPrice": {
+            "additionalProperties": true,
+            "properties": {
+              "taxPortions": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "amount": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "centAmount": {
+                          "type": "integer"
+                        },
+                        "currencyCode": {
+                          "type": "string"
+                        },
+                        "fractionDigits": {
+                          "type": "integer"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "rate": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "totalGross": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "totalNet": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "totalTax": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "taxedPricePortions": {
+            "type": "array"
+          },
+          "totalPrice": {
+            "additionalProperties": true,
+            "properties": {
+              "centAmount": {
+                "type": "integer"
+              },
+              "currencyCode": {
+                "type": "string"
+              },
+              "fractionDigits": {
+                "type": "integer"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "customerEmail": {
+      "type": "string"
+    },
+    "customerGroup": {
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "typeId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "customerId": {
+      "type": "string"
+    },
+    "deleteDaysAfterLastModification": {
+      "type": "integer"
+    },
+    "directDiscounts": {
+      "type": "array"
+    },
+    "discountCodes": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "discountCode": {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "typeId": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "id": {
+      "type": "string"
+    },
+    "inventoryMode": {
+      "type": "string"
+    },
+    "itemShippingAddresses": {
+      "type": "array"
+    },
+    "lastMessageSequenceNumber": {
+      "type": "integer"
+    },
+    "lastModifiedAt": {
+      "type": "string"
+    },
+    "lastModifiedBy": {
+      "additionalProperties": true,
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "isPlatformClient": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "lineItems": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "addedAt": {
+            "type": "string"
+          },
+          "custom": {
+            "additionalProperties": true,
+            "properties": {
+              "fields": {
+                "additionalProperties": true,
+                "properties": {
+                  "external-id": {
+                    "type": "string"
+                  },
+                  "parent": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": {
+                "additionalProperties": true,
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "typeId": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "discountedPrice": {
+            "additionalProperties": true,
+            "properties": {
+              "includedDiscounts": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "discount": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "typeId": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "discountedAmount": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "centAmount": {
+                          "type": "integer"
+                        },
+                        "currencyCode": {
+                          "type": "string"
+                        },
+                        "fractionDigits": {
+                          "type": "integer"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "value": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "discountedPricePerQuantity": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "discountedPrice": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "includedDiscounts": {
+                      "items": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "discount": {
+                            "additionalProperties": true,
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "typeId": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "discountedAmount": {
+                            "additionalProperties": true,
+                            "properties": {
+                              "centAmount": {
+                                "type": "integer"
+                              },
+                              "currencyCode": {
+                                "type": "string"
+                              },
+                              "fractionDigits": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "value": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "centAmount": {
+                          "type": "integer"
+                        },
+                        "currencyCode": {
+                          "type": "string"
+                        },
+                        "fractionDigits": {
+                          "type": "integer"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "quantity": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastModifiedAt": {
+            "type": "string"
+          },
+          "lineItemMode": {
+            "type": "string"
+          },
+          "name": {
+            "additionalProperties": true,
+            "properties": {
+              "en-US": {
+                "type": "string"
+              },
+              "es-MX": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "perMethodTaxRate": {
+            "type": "array"
+          },
+          "price": {
+            "additionalProperties": true,
+            "properties": {
+              "customerGroup": {
+                "additionalProperties": true,
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "typeId": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "validFrom": {
+                "type": "string"
+              },
+              "validUntil": {
+                "type": "string"
+              },
+              "value": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "priceMode": {
+            "type": "string"
+          },
+          "productId": {
+            "type": "string"
+          },
+          "productKey": {
+            "type": "string"
+          },
+          "productSlug": {
+            "additionalProperties": true,
+            "properties": {
+              "en-US": {
+                "type": "string"
+              },
+              "es-MX": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "productType": {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "typeId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "quantity": {
+            "type": "integer"
+          },
+          "state": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "quantity": {
+                  "type": "integer"
+                },
+                "state": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "typeId": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "supplyChannel": {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "typeId": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "taxRate": {
+            "additionalProperties": true,
+            "properties": {
+              "amount": {
+                "type": "number"
+              },
+              "country": {
+                "type": "string"
+              },
+              "includedInPrice": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              },
+              "subRates": {
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "taxedPrice": {
+            "additionalProperties": true,
+            "properties": {
+              "taxPortions": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "amount": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "centAmount": {
+                          "type": "integer"
+                        },
+                        "currencyCode": {
+                          "type": "string"
+                        },
+                        "fractionDigits": {
+                          "type": "integer"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "rate": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "totalGross": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "totalNet": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "totalTax": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "taxedPricePortions": {
+            "type": "array"
+          },
+          "totalPrice": {
+            "additionalProperties": true,
+            "properties": {
+              "centAmount": {
+                "type": "integer"
+              },
+              "currencyCode": {
+                "type": "string"
+              },
+              "fractionDigits": {
+                "type": "integer"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "variant": {
+            "additionalProperties": true,
+            "properties": {
+              "assets": {
+                "type": "array"
+              },
+              "attributes": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": [
+                            "boolean",
+                            "number",
+                            "string"
+                          ]
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "additionalProperties": true,
+                                "properties": {
+                                  "en-US": {
+                                    "type": "string"
+                                  },
+                                  "es-MX": {
+                                    "type": "string"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "typeId": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "items": {
+                                  "additionalProperties": true,
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "additionalProperties": true,
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "typeId": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "additionalProperties": true,
+                          "properties": {
+                            "en-US": {
+                              "type": "string"
+                            },
+                            "es-MX": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "typeId": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "availability": {
+                "additionalProperties": true,
+                "properties": {
+                  "availableQuantity": {
+                    "type": "integer"
+                  },
+                  "channels": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "1fd6c4cf-ac1b-4bf2-a3f5-8a6f788719e7": {
+                        "additionalProperties": true,
+                        "properties": {
+                          "availableQuantity": {
+                            "type": "integer"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "isOnStock": {
+                            "type": "boolean"
+                          },
+                          "version": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "isOnStock": {
+                    "type": "boolean"
+                  },
+                  "version": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "images": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "dimensions": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "h": {
+                          "type": "integer"
+                        },
+                        "w": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "key": {
+                "type": "string"
+              },
+              "prices": {
+                "type": "array"
+              },
+              "sku": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "origin": {
+      "type": "string"
+    },
+    "paymentInfo": {
+      "additionalProperties": true,
+      "properties": {
+        "payments": {
+          "items": {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "typeId": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "refusedGifts": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "typeId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "shipping": {
+      "type": "array"
+    },
+    "shippingAddress": {
+      "additionalProperties": true,
+      "properties": {
+        "additionalAddressInfo": {
+          "type": "string"
+        },
+        "additionalStreetInfo": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "streetName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "shippingInfo": {
+      "additionalProperties": true,
+      "properties": {
+        "deliveries": {
+          "type": "array"
+        },
+        "price": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "shippingMethod": {
+          "additionalProperties": true,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "typeId": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "shippingMethodName": {
+          "type": "string"
+        },
+        "shippingMethodState": {
+          "type": "string"
+        },
+        "shippingRate": {
+          "additionalProperties": true,
+          "properties": {
+            "freeAbove": {
+              "additionalProperties": true,
+              "properties": {
+                "centAmount": {
+                  "type": "integer"
+                },
+                "currencyCode": {
+                  "type": "string"
+                },
+                "fractionDigits": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "price": {
+              "additionalProperties": true,
+              "properties": {
+                "centAmount": {
+                  "type": "integer"
+                },
+                "currencyCode": {
+                  "type": "string"
+                },
+                "fractionDigits": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "tiers": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "taxRate": {
+          "additionalProperties": true,
+          "properties": {
+            "amount": {
+              "type": "number"
+            },
+            "country": {
+              "type": "string"
+            },
+            "includedInPrice": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "subRates": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "taxedPrice": {
+          "additionalProperties": true,
+          "properties": {
+            "taxPortions": {
+              "items": {
+                "additionalProperties": true,
+                "properties": {
+                  "amount": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "centAmount": {
+                        "type": "integer"
+                      },
+                      "currencyCode": {
+                        "type": "string"
+                      },
+                      "fractionDigits": {
+                        "type": "integer"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "rate": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "totalGross": {
+              "additionalProperties": true,
+              "properties": {
+                "centAmount": {
+                  "type": "integer"
+                },
+                "currencyCode": {
+                  "type": "string"
+                },
+                "fractionDigits": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "totalNet": {
+              "additionalProperties": true,
+              "properties": {
+                "centAmount": {
+                  "type": "integer"
+                },
+                "currencyCode": {
+                  "type": "string"
+                },
+                "fractionDigits": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "totalTax": {
+              "additionalProperties": true,
+              "properties": {
+                "centAmount": {
+                  "type": "integer"
+                },
+                "currencyCode": {
+                  "type": "string"
+                },
+                "fractionDigits": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "shippingMode": {
+      "type": "string"
+    },
+    "store": {
+      "additionalProperties": true,
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "typeId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "taxCalculationMode": {
+      "type": "string"
+    },
+    "taxMode": {
+      "type": "string"
+    },
+    "taxRoundingMode": {
+      "type": "string"
+    },
+    "taxedPrice": {
+      "additionalProperties": true,
+      "properties": {
+        "taxPortions": {
+          "items": {
+            "additionalProperties": true,
+            "properties": {
+              "amount": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "rate": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "totalGross": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "totalNet": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "totalTax": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "taxedShippingPrice": {
+      "additionalProperties": true,
+      "properties": {
+        "taxPortions": {
+          "items": {
+            "additionalProperties": true,
+            "properties": {
+              "amount": {
+                "additionalProperties": true,
+                "properties": {
+                  "centAmount": {
+                    "type": "integer"
+                  },
+                  "currencyCode": {
+                    "type": "string"
+                  },
+                  "fractionDigits": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "rate": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "totalGross": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "totalNet": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "totalTax": {
+          "additionalProperties": true,
+          "properties": {
+            "centAmount": {
+              "type": "integer"
+            },
+            "currencyCode": {
+              "type": "string"
+            },
+            "fractionDigits": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "totalLineItemQuantity": {
+      "type": "integer"
+    },
+    "totalPrice": {
+      "additionalProperties": true,
+      "properties": {
+        "centAmount": {
+          "type": "integer"
+        },
+        "currencyCode": {
+          "type": "string"
+        },
+        "fractionDigits": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "type": {
+      "type": "string"
+    },
+    "version": {
+      "type": "integer"
+    },
+    "versionModifiedAt": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/airbyte-integrations/connectors/source-commercetools/source_commercetools/schemas/inventory.json
+++ b/airbyte-integrations/connectors/source-commercetools/source_commercetools/schemas/inventory.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "availableQuantity": {
+      "type": "integer"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "createdBy": {
+      "additionalProperties": true,
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "isPlatformClient": {
+          "type": "boolean"
+        },
+        "user": {
+          "additionalProperties": true,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "typeId": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "id": {
+      "type": "string"
+    },
+    "key": {
+      "type": "string"
+    },
+    "lastMessageSequenceNumber": {
+      "type": "integer"
+    },
+    "lastModifiedAt": {
+      "type": "string"
+    },
+    "lastModifiedBy": {
+      "additionalProperties": true,
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "isPlatformClient": {
+          "type": "boolean"
+        },
+        "user": {
+          "additionalProperties": true,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "typeId": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "quantityOnStock": {
+      "type": "integer"
+    },
+    "reservations": {
+      "type": "array"
+    },
+    "sku": {
+      "type": "string"
+    },
+    "supplyChannel": {
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "typeId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "version": {
+      "type": "integer"
+    },
+    "versionModifiedAt": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
This adds these two streams to commercetools:
- carts
- inventory
## How
<!--
* Describe how code changes achieve the solution.
-->
It defines them in the manifest file found here: `airbyte-integrations/connectors/source-commercetools/source_commercetools/manifest.yaml`

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
Review airbyte-integrations/connectors/source-commercetools/source_commercetools/manifest.yaml

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
They can collect more data from commercetools

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x ] YES 💚
