### PR TITLE
fix: Products endpoint for Akeneo

### DIFF
--- a/airbyte-integrations/connectors/source-akeneo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-akeneo/manifest.yaml
@@ -27,7 +27,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /products-uuid
+          path: /products
           http_method: GET
         record_selector:
           type: RecordSelector


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
- Products endpoint for Akeneo has been changed from `\products-uuid` to `\products` which was making the connector to fail while checking the credentials.
- Fixing this issue should enable the Akeneo connector to run at full potential by enabling all the supported non-incremental endpoints.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
